### PR TITLE
#1: Add Shorter Names

### DIFF
--- a/docs/extended_api/actions.rst
+++ b/docs/extended_api/actions.rst
@@ -18,7 +18,7 @@ SendAPIRequest
 --------------
 
 This Action is a bit special.
-For code repetition's sake,
+For code DRYness' sake,
 all of the ``Send{METHOD}Request`` Actions
 use this Action;
 but for readability's sake,
@@ -26,15 +26,13 @@ you will want to use
 the appropriate ``Send{METHOD}Request`` Action
 listed below.
 
-In order to show the full documentation
-for all of these Actions,
-this Action needed to be included.
-
 .. autoclass:: SendAPIRequest
     :members:
 
 SendDELETERequest
 ^^^^^^^^^^^^^^^^^
+
+**Aliases**: Delete
 
 .. autoclass:: SendDELETERequest
     :members:
@@ -42,11 +40,15 @@ SendDELETERequest
 SendGETRequest
 ^^^^^^^^^^^^^^
 
+**Aliases**: Get
+
 .. autoclass:: SendGETRequest
     :members:
 
 SendHEADRequest
 ^^^^^^^^^^^^^^^
+
+**Aliases**: Head
 
 .. autoclass:: SendHEADRequest
     :members:
@@ -54,11 +56,15 @@ SendHEADRequest
 SendOPTIONSRequest
 ^^^^^^^^^^^^^^^^^^
 
+**Aliases**: Options
+
 .. autoclass:: SendOPTIONSRequest
     :members:
 
 SendPATCHRequest
 ^^^^^^^^^^^^^^^^
+
+**Aliases**: Patch
 
 .. autoclass:: SendPATCHRequest
     :members:
@@ -66,11 +72,15 @@ SendPATCHRequest
 SendPOSTRequest
 ^^^^^^^^^^^^^^^
 
+**Aliases**: Post
+
 .. autoclass:: SendPOSTRequest
     :members:
 
 SendPUTRequest
 ^^^^^^^^^^^^^^
+
+**Aliases**: Put
 
 .. autoclass:: SendPUTRequest
     :members:

--- a/docs/extended_api/questions.rst
+++ b/docs/extended_api/questions.rst
@@ -9,7 +9,7 @@ These are the Questions added in ScreenPy Requests.
 BodyOfTheLastResponse
 ---------------------
 
-**Aliases**: TheBodyOfTheLastResponse
+**Aliases**: Body, TheBody, TheBodyOfTheLastResponse
 
 .. autoclass:: BodyOfTheLastResponse
     :members:
@@ -25,7 +25,7 @@ Cookies
 HeadersOfTheLastResponse
 ------------------------
 
-**Aliases**: TheHeadersOfTheLastResponse
+**Aliases**: Headers, TheHeaders, TheHeadersOfTheLastResponse
 
 .. autoclass:: HeadersOfTheLastResponse
     :members:
@@ -33,7 +33,7 @@ HeadersOfTheLastResponse
 StatusCodeOfTheLastResponse
 ---------------------------
 
-**Aliases**: TheStatusCodeOfTheLastResponse
+**Aliases**: StatusCode, TheStatusCode, TheStatusCodeOfTheLastResponse
 
 .. autoclass:: StatusCodeOfTheLastResponse
     :members:

--- a/screenpy_requests/actions/__init__.py
+++ b/screenpy_requests/actions/__init__.py
@@ -15,7 +15,6 @@ class APIMethodAction(Protocol):
     @staticmethod
     def to(url: str) -> SendAPIRequest:
         """Set the URL this request will be sent to."""
-        ...
 
 
 def generate_send_method_class(method: str) -> Type[APIMethodAction]:
@@ -182,11 +181,25 @@ SendPUTRequest = generate_send_method_class("PUT")
 
 # Natural-language-enabling syntactic sugar
 AddHeaders = AddHeader
+Delete = SendDELETERequest
+Get = SendGETRequest
+Head = SendHEADRequest
+Options = SendOPTIONSRequest
+Patch = SendPATCHRequest
+Post = SendPOSTRequest
+Put = SendPUTRequest
 
 
 __all__ = [
     "AddHeader",
     "AddHeaders",
+    "Delete",
+    "Get",
+    "Head",
+    "Options",
+    "Patch",
+    "Post",
+    "Put",
     "SendDELETERequest",
     "SendGETRequest",
     "SendHEADRequest",

--- a/screenpy_requests/questions/__init__.py
+++ b/screenpy_requests/questions/__init__.py
@@ -8,19 +8,25 @@ from .headers_of_the_last_response import HeadersOfTheLastResponse
 from .status_code_of_the_last_response import StatusCodeOfTheLastResponse
 
 # Natural-language-enabling syntactic sugar
-TheBodyOfTheLastResponse = BodyOfTheLastResponse
+TheBody = Body = TheBodyOfTheLastResponse = BodyOfTheLastResponse
 TheCookies = Cookies
-TheHeadersOfTheLastResponse = HeadersOfTheLastResponse
+TheHeaders = Headers = TheHeadersOfTheLastResponse = HeadersOfTheLastResponse
 TheStatusCodeOfTheLastResponse = StatusCodeOfTheLastResponse
-
+TheStatusCode = StatusCode = StatusCodeOfTheLastResponse
 
 __all__ = [
+    "Body",
     "BodyOfTheLastResponse",
     "Cookies",
+    "Headers",
     "HeadersOfTheLastResponse",
+    "StatusCode",
     "StatusCodeOfTheLastResponse",
+    "TheBody",
     "TheBodyOfTheLastResponse",
     "TheCookies",
+    "TheHeaders",
     "TheHeadersOfTheLastResponse",
+    "TheStatusCode",
     "TheStatusCodeOfTheLastResponse",
 ]


### PR DESCRIPTION
This PR adds some more, shorter aliases for the Actions and Questions provided in ScreenPy Requests.